### PR TITLE
Update pre-commit hooks and add tofu-scan

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,7 +11,7 @@ repos:
       - id: check-symlinks
 
   - repo: https://github.com/osinfra-io/pt-techne-pre-commit-hooks
-    rev: fe697ad1e9131053bd379a1ca110904f220612fd # frozen: v0.1.3
+    rev: bf174b5f94101025ee45458e820d7ad693e21df1 # frozen: v0.1.5
     hooks:
       - id: tofu-fmt
         verbose: true
@@ -25,4 +25,7 @@ repos:
         verbose: true
 
       - id: tofu-test
+        verbose: true
+
+      - id: tofu-scan
         verbose: true


### PR DESCRIPTION
Update pre-commit hooks:

- Bump `pt-techne-pre-commit-hooks` to v0.1.4
- Add `tofu-scan` hook for CIS benchmark scanning (GCP Foundation v3.0.0 + GKE v1.6.1)
- Pin all hook revisions to frozen commit SHAs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Pinned pre-commit hooks to a frozen revision to ensure consistent checks.
  * Added a new tofu-scan hook (enabled in verbose mode) to improve pre-commit scanning and validation.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/osinfra-io/pt-arche-google-cloud-sql/pull/84)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->