### PR TITLE
Update pt-arche-core-helpers to v0.3.2

### DIFF
--- a/regional/helpers.tofu
+++ b/regional/helpers.tofu
@@ -2,5 +2,5 @@
 # https://github.com/osinfra-io/pt-arche-core-helpers
 
 module "core_helpers" {
-  source = "github.com/osinfra-io/pt-arche-core-helpers//child?ref=70c1e4f4a11acdcfc36055bdd3aa16579d4203a1" # v0.3.1
+  source = "github.com/osinfra-io/pt-arche-core-helpers//child?ref=7e9435f875ac91ac8538385fe8b4554dd068673e" # v0.3.2
 }


### PR DESCRIPTION
Bumps the pt-arche-core-helpers SHA pin to v0.3.2.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Completed a routine internal maintenance update.
  * No user-facing functionality or behavior changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->