### PR TITLE
Use release called workflow from pt-techne-misc-workflows

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,18 +7,11 @@ on:
 
 permissions:
   contents: write
+  id-token: write
 
 jobs:
   release:
-    name: "Release"
-    runs-on: ubuntu-latest
-    steps:
-      - name: Create Release
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          TAG: ${{ github.ref_name }}
-        run: |
-          gh release create "$TAG" \
-            --repo "${{ github.repository }}" \
-            --title "$TAG" \
-            --generate-notes
+    name: Release
+    uses: osinfra-io/pt-techne-misc-workflows/.github/workflows/release.yml@cd7f9e2c86fe5bbafd21b8f12cc0e6cbe504f0f7  # v0.2.8
+    secrets:
+      token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Replaces the inline `gh release create` step with the shared release called workflow from `osinfra-io/pt-techne-misc-workflows`, which handles the case where a release already exists (e.g. created manually before the workflow runs).

Pins to `osinfra-io/pt-techne-misc-workflows` `v0.2.8` (`cd7f9e2c86fe5bbafd21b8f12cc0e6cbe504f0f7`).

Part of osinfra-io/pt-techne-misc-workflows#187

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the release automation to use a standardized shared workflow.
  * Improved release authentication and permission handling.
  * Release creation remains automated with no changes to the product experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->