### PR TITLE
Add optional deterministic instance name

### DIFF
--- a/regional/locals.tofu
+++ b/regional/locals.tofu
@@ -4,7 +4,7 @@
 locals {
   database_flags = startswith(var.database_version, "POSTGRES_") ? local.postgres_database_flags : []
 
-  name    = "${var.instance_name}-${random_id.this.hex}-${var.region}"
+  name    = var.random_id_suffix ? "${var.instance_name}-${random_id.this[0].hex}-${var.region}" : "${var.instance_name}-${var.region}"
   network = "projects/${var.host_project_id}/global/networks/${var.network}"
 
   # These flags are required for CIS GCP v1.3.0 compliance

--- a/regional/main.tofu
+++ b/regional/main.tofu
@@ -67,6 +67,8 @@ resource "google_sql_ssl_cert" "this" {
 # https://search.opentofu.org/provider/hashicorp/random/latest/docs/resources/id
 
 resource "random_id" "this" {
+  count = var.random_id_suffix ? 1 : 0
+
   byte_length = "1"
   prefix      = "tf"
 }

--- a/regional/variables.tofu
+++ b/regional/variables.tofu
@@ -109,6 +109,12 @@ variable "query_string_length" {
   type        = number
 }
 
+variable "random_id_suffix" {
+  default     = true
+  description = "Whether to append a random ID suffix to the instance name. Set to false for a deterministic name of instance_name-region that consumers can reference without reading state"
+  type        = bool
+}
+
 variable "record_application_tags" {
   default     = true
   description = "True if Query Insights will record application tags from query when enabled"

--- a/tests/default.tftest.hcl
+++ b/tests/default.tftest.hcl
@@ -25,3 +25,20 @@ variables {
   instance_name   = "mock-instance"
   project         = "mock-project"
 }
+
+run "deterministic_instance_name" {
+  command = apply
+
+  module {
+    source = "./tests/fixtures/default"
+  }
+
+  variables {
+    random_id_suffix = false
+  }
+
+  assert {
+    condition     = output.instance == "mock-instance-mock-region"
+    error_message = "Instance name should omit the random ID suffix when random_id_suffix is false"
+  }
+}

--- a/tests/fixtures/default/main.tofu
+++ b/tests/fixtures/default/main.tofu
@@ -36,5 +36,8 @@ module "test" {
   ]
 
   project = var.project
-  region  = "mock-region"
+
+  random_id_suffix = var.random_id_suffix
+
+  region = "mock-region"
 }

--- a/tests/fixtures/default/outputs.tofu
+++ b/tests/fixtures/default/outputs.tofu
@@ -1,0 +1,7 @@
+# Output Values
+# https://opentofu.org/docs/language/values/outputs
+
+output "instance" {
+  description = "SQL instance name"
+  value       = module.test.instance
+}

--- a/tests/fixtures/default/variables.tofu
+++ b/tests/fixtures/default/variables.tofu
@@ -24,3 +24,10 @@ variable "project" {
 
   type = string
 }
+
+variable "random_id_suffix" {
+  default     = true
+  description = "Whether to append a random ID suffix to the instance name"
+
+  type = bool
+}


### PR DESCRIPTION
Adds a `random_id_suffix` input (default `true`, preserving existing behavior). When set to `false`, the instance name is deterministic (`instance_name-region`), so a consuming repository can reference the instance by name without reading the creating repository's Terraform state.

This unblocks dogfooding the platform-managed Cloud SQL in pt-pneuma (#142): corpus creates the instance with a stable name and a private DNS record, and pneuma manages the `authentik` database/user on it by referencing that name.

- Added `random_id_suffix` variable and gated `random_id.this` with `count`.
- Added a test run asserting the deterministic name path.